### PR TITLE
Added stylelint --fix support

### DIFF
--- a/lint/stylelint.js
+++ b/lint/stylelint.js
@@ -3,19 +3,22 @@ const getVarsByProps = require('../variables.js');
 const findInValue = require('../utils.js').findInValue;
 
 const ruleName = 'arui-cssvars/use-variables';
+const formatVar = variable => `var(${variable})`;
 const messages = stylelint.utils.ruleMessages(ruleName, {
     expected: function (variable, value) {
-        return `Use variable 'var(${variable})' instead of plain value '${value}'`;
+        return `Use variable '${formatVar(variable)}' instead of plain value '${value}'`;
     }
 });
 
 function find(value, group) {
     for (let index = 0 ; index < group.length ; ++index) {
         for (key in group[index]) {
-            if (findInValue(value, key) !== false) {
+            const valueIndex = findInValue(value, key);
+            if (valueIndex !== false) {
                 return {
                     value: key,
-                    variable: group[index][key]
+                    valueIndex,
+                    variable: group[index][key],
                 };
             }
         }
@@ -34,19 +37,28 @@ module.exports = stylelint.createPlugin(ruleName, function (enabled, _, context)
     return function (root, result) {
         root.walkDecls(function (decl) {
             if (decl.prop in varsByProps) {
-                const substitution = find(decl.value, varsByProps[decl.prop]);
-                if (substitution) {
+                let { value } = decl;
+                let substitution;
+                const previousValues = [];
+                while ((substitution = find(value, varsByProps[decl.prop]))) {
+                    const fixedValue = formatVar(substitution.variable);
+                    value = value.replace(substitution.value, fixedValue);
                     if (context.fix) {
-                        decl.value = decl.value.replace(substitution.value, `var(${substitution.variable})`);
-                        return;
+                        decl.value = value;
+                    } else {
+                        const originalValueIndex = previousValues.reduce((acc, sub) => acc > sub.valueIndex + sub.diff
+                            ? acc - sub.diff
+                            : acc, substitution.valueIndex);
+                        stylelint.utils.report({
+                            result,
+                            ruleName,
+                            message: messages.expected(substitution.variable, substitution.value),
+                            node: decl,
+                            word: decl.value,
+                            index: originalValueIndex + decl.prop.length + decl.raws.between.length,
+                        });
+                        previousValues.unshift({...substitution, diff: fixedValue.length - substitution.value.length});
                     }
-                    stylelint.utils.report({
-                        result,
-                        ruleName,
-                        message: messages.expected(substitution.variable, substitution.value),
-                        node: decl,
-                        word: decl.value
-                    });
                 }
             }
         });

--- a/lint/stylelint.js
+++ b/lint/stylelint.js
@@ -22,7 +22,7 @@ function find(value, group) {
     }
 }
 
-module.exports = stylelint.createPlugin(ruleName, function (enabled) {
+module.exports = stylelint.createPlugin(ruleName, function (enabled, _, context) {
     if (!enabled) {
         return function () {
             return null;
@@ -36,6 +36,10 @@ module.exports = stylelint.createPlugin(ruleName, function (enabled) {
             if (decl.prop in varsByProps) {
                 const substitution = find(decl.value, varsByProps[decl.prop]);
                 if (substitution) {
+                    if (context.fix) {
+                        decl.value = decl.value.replace(substitution.value, `var(${substitution.variable})`);
+                        return;
+                    }
                     stylelint.utils.report({
                         result,
                         ruleName,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arui-cssvars",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Helper for arui-feather css variables",
   "main": "index.js",
   "scripts": {

--- a/test/test.css
+++ b/test/test.css
@@ -6,3 +6,20 @@
   /* stylelint-disable-next-line arui-cssvars/use-variables */
   margin-right: 20px;
 }
+
+.test-multiple {
+  margin: 8px 16px 4px 8px;
+  padding: 8px 16px 4px 32px;
+  font-size: 16px;
+}
+
+.test-triple {
+  margin: 8px 4px -16px;
+  padding: 32px 0 0px 16px;
+  font-size: 16px;
+}
+
+.test-negative {
+  margin: -8px 4px -16px -32px;
+  padding: -32px 0 0px 16px;
+}


### PR DESCRIPTION
Небольшая доработка, добавляющая возможность исправлять найденные значения на предложенные переменные.
Пример работы:
![image](https://user-images.githubusercontent.com/6886122/96993381-e7b75800-1533-11eb-9260-da3f83eed824.png)

Из минусов: 
т.к. сейчас правило триггерится на одно значение из строки есть кейсы когда для исправления такого
```
margin: 8px 16px 16px 8px;
```
нужно будет вызвать `stylelint --fix` 4 раза.
Исправение этого требует чуть больших доработок, но сейчас это лучше, чем исправлять в большом проекте всё руками.